### PR TITLE
Edits to allow NDIToolbox to run using wxPython 4.0.3; incomplete upgrade

### DIFF
--- a/controllers/mainui_ctrl.py
+++ b/controllers/mainui_ctrl.py
@@ -75,7 +75,7 @@ class MainUIController(object):
         """Returns a wx.Icon of the application's
         default icon"""
         if sys.platform != 'win32':
-            return wx.IconFromBitmap(self.get_icon_bmp())
+            return wx.Icon(self.get_icon_bmp())
         icon = wx.Icon(pathfinder.winicon_path(), wx.BITMAP_TYPE_ICO)
         return icon
 
@@ -134,7 +134,7 @@ class MainUIController(object):
     def on_quit(self, evt):
         """Handles the Quit event"""
         self.model.set_coords(list(self.view.GetPosition()))
-        self.model.set_window_size(list(self.view.GetClientSizeTuple()))
+        self.model.set_window_size(list(self.view.GetClientSize()))
         self.view._mgr.UnInit()
         self.view.Destroy()
 
@@ -359,7 +359,10 @@ class MainUIController(object):
     def on_choose_loglevel(self, evt):
         """Handles request to set the log level severity"""
         available_log_levels = mainmodel.available_log_levels
-        current_log_level_str = available_log_levels[0]
+#        available_log_levels is a hash keyed by strings; cannot use 0 as key
+#        'warning' log level chosen as default
+#        current_log_level_str = available_log_levels[0]
+        current_log_level_str = 'warning'
         log_level_strs = available_log_levels.keys()
         current_log_level = mainmodel.get_loglevel()
         for log_str, log_lvl in available_log_levels.iteritems():

--- a/controllers/thumbnailpanel_ctrl.py
+++ b/controllers/thumbnailpanel_ctrl.py
@@ -22,8 +22,7 @@ class ThumbnailPanelController(object):
 
     def empty_bitmap(self, width, height):
         """Creates and returns an empty wxBitmap of the given width and height"""
-        fg_color = wx.NullColor
-        return wx.EmptyBitmapRGBA(width, height, fg_color.Red(), fg_color.Green(), fg_color.Blue())
+        return wx.Bitmap.FromRGBA(width, height)
 
     def plot_thumb(self, data_fname, width, height):
         """Creates (if necessary) and retrieves a matplotlib plot of the specified

--- a/views/mainui.py
+++ b/views/mainui.py
@@ -55,38 +55,38 @@ class UI(wx.Frame):
         self.file_mnu = wx.Menu()
         self.import_mnu = wx.Menu()
         hdf5_mnui = wx.MenuItem(self.import_mnu, wx.ID_ANY, text="HDF5 File...",
-                                help="Copies an HDF5 file to your NDIToolbox data folder")
+                                helpString="Copies an HDF5 file to your NDIToolbox data folder")
         self.import_mnu.AppendItem(hdf5_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_import_hdf5, id=hdf5_mnui.GetId())
         txt_mnui = wx.MenuItem(self.import_mnu, wx.ID_ANY, text="Text File (CSV, etc.)...",
-                               help="Imports delimited ASCII data file")
+                               helpString="Imports delimited ASCII data file")
         self.import_mnu.AppendItem(txt_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_import_text, id=txt_mnui.GetId())
         csc_mnui = wx.MenuItem(self.import_mnu, wx.ID_ANY, text="UTWin CScan (.csc)...",
-                               help="Imports a .csc file")
+                               helpString="Imports a .csc file")
         self.import_mnu.AppendItem(csc_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_import_csc, id=csc_mnui.GetId())
         sdt_mnui = wx.MenuItem(self.import_mnu, wx.ID_ANY, text="Winspect 6/7 CScan (.sdt)...",
-                               help="Imports a .sdt file")
+                               helpString="Imports a .sdt file")
         self.import_mnu.AppendItem(sdt_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_import_sdt, id=sdt_mnui.GetId())
         dicom_mnui = wx.MenuItem(self.import_mnu, wx.ID_ANY, text="DICOM/DICONDE...",
-                                 help="Imports a DICOM / DICONDE data file")
+                                 helpString="Imports a DICOM / DICONDE data file")
         self.import_mnu.AppendItem(dicom_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_import_dicom, id=dicom_mnui.GetId())
         img_mnui = wx.MenuItem(self.import_mnu, wx.ID_ANY, text="Image...",
-                               help="Imports an image file")
+                               helpString="Imports an image file")
         self.Bind(wx.EVT_MENU, self.controller.on_import_image, id=img_mnui.GetId())
         self.import_mnu.AppendItem(img_mnui)
         self.file_mnu.AppendMenu(wx.ID_ANY, 'Import...', self.import_mnu)
         self.file_mnu.AppendSeparator()
         browsedata_mnui = wx.MenuItem(self.file_mnu, wx.ID_ANY, text="Show Data Folder",
-                                      help="Opens the local storage folder")
+                                      helpString="Opens the local storage folder")
         self.file_mnu.AppendItem(browsedata_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_browse_userpath, id=browsedata_mnui.GetId())
         self.file_mnu.AppendSeparator()
         quit_mnui = wx.MenuItem(self.file_mnu, wx.ID_ANY, text="E&xit\tCTRL+X",
-                                help="Exit The Program")
+                                helpString="Exit The Program")
         self.file_mnu.AppendItem(quit_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_quit, id=quit_mnui.GetId())
         self.menubar.Append(self.file_mnu, "&File")
@@ -95,22 +95,22 @@ class UI(wx.Frame):
         """Creates the Tools menu"""
         self.tool_mnu = wx.Menu()
         podtk_mnui = wx.MenuItem(self.tool_mnu, wx.ID_ANY, text="POD Toolkit",
-                                 help="Runs the Probability Of Detection Toolkit")
+                                 helpString="Runs the Probability Of Detection Toolkit")
         self.tool_mnu.AppendItem(podtk_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_run_podtk, id=podtk_mnui.GetId())
         self.prefs_mnu = wx.Menu() # Preferences Menu
         userpath_mnui = wx.MenuItem(self.prefs_mnu, wx.ID_ANY, text="Choose Data Folder...",
-                                    help="Specify the local storage folder")
+                                    helpString="Specify the local storage folder")
         self.prefs_mnu.AppendItem(userpath_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_choose_userpath, id=userpath_mnui.GetId())
         log_mnui = wx.MenuItem(self.prefs_mnu, wx.ID_ANY, text="Choose Logging Level...",
-                                    help="Specify the severity of events recorded in the application log")
+                                    helpString="Specify the severity of events recorded in the application log")
         self.prefs_mnu.AppendItem(log_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_choose_loglevel, id=log_mnui.GetId())
         self.tool_mnu.AppendMenu(wx.ID_ANY, 'Preferences', self.prefs_mnu)
         self.tool_mnu.AppendSeparator()
         gc_mnui = wx.MenuItem(self.tool_mnu, wx.ID_ANY, text="Free Memory...",
-                              help="Attempt to free up memory by scheduling garbage collection")
+                              helpString="Attempt to free up memory by scheduling garbage collection")
         self.tool_mnu.AppendItem(gc_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_gc, id=gc_mnui.GetId())
         self.menubar.Append(self.tool_mnu, "&Tools")
@@ -119,52 +119,52 @@ class UI(wx.Frame):
         """Creates the Help menu"""
         self.help_mnu = wx.Menu()
         help_mnui = wx.MenuItem(self.help_mnu, wx.ID_ANY, text="Help Topics",
-                                help="Opens the help documentation in your web browser")
+                                helpString="Opens the help documentation in your web browser")
         self.help_mnu.AppendItem(help_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_help, id=help_mnui.GetId())
         quickstart_mnui = wx.MenuItem(self.help_mnu, wx.ID_ANY, text="Getting Started",
-                                      help="Opens the Getting Started Guide")
+                                      helpString="Opens the Getting Started Guide")
         self.help_mnu.AppendItem(quickstart_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_quickstart, id=quickstart_mnui.GetId())
 
         self.plugins_mnu = wx.Menu()
         plugins_mnui = wx.MenuItem(self.plugins_mnu, wx.ID_ANY, text="Using Plugins",
-                                   help="Opens introduction to using NDIToolbox plugins")
+                                   helpString="Opens introduction to using NDIToolbox plugins")
         self.plugins_mnu.AppendItem(plugins_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_plugins, id=plugins_mnui.GetId())
         plugins_dev_mnui = wx.MenuItem(self.plugins_mnu, wx.ID_ANY, text="Writing Plugins",
-                                       help="Opens introduction to writing NDIToolbox plugins")
+                                       helpString="Opens introduction to writing NDIToolbox plugins")
         self.plugins_mnu.AppendItem(plugins_dev_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_plugins_dev, id=plugins_dev_mnui.GetId())
         plugins_samples_mnui = wx.MenuItem(self.plugins_mnu, wx.ID_ANY, text="Examples",
-                                           help="Opens examples of NDIToolbox plugins")
+                                           helpString="Opens examples of NDIToolbox plugins")
         self.plugins_mnu.AppendItem(plugins_samples_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_plugins_samples, id=plugins_samples_mnui.GetId())
         self.help_mnu.AppendMenu(wx.ID_ANY, "NDIToolbox Plugins", self.plugins_mnu)
         self.help_mnu.AppendSeparator()
         about_mnui = wx.MenuItem(self.help_mnu, wx.ID_ANY, text="About This Program...",
-                                 help="About This Program")
+                                 helpString="About This Program")
         self.help_mnu.AppendItem(about_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_about, id=about_mnui.GetId())
         license_mnui = wx.MenuItem(self.help_mnu, wx.ID_ANY, text="License Information...",
-                                   help="License Information")
+                                   helpString="License Information")
         self.help_mnu.AppendItem(license_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_about_license, id=license_mnui.GetId())
         about_tri_mnui = wx.MenuItem(self.help_mnu, wx.ID_ANY, text='About TRI/Austin...',
-                                     help="About TRI/Austin's NDE Division")
+                                     helpString="About TRI/Austin's NDE Division")
         self.help_mnu.AppendItem(about_tri_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_about_tri, id=about_tri_mnui.GetId())
         about_icons_mnui = wx.MenuItem(self.help_mnu, wx.ID_ANY, text="About Axialis Icons...",
-                                       help="About the Axialis icons used in this project")
+                                       helpString="About the Axialis icons used in this project")
         self.help_mnu.AppendItem(about_icons_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_about_icons, id=about_icons_mnui.GetId())
         self.help_mnu.AppendSeparator()
         displaylog_mnui = wx.MenuItem(self.help_mnu, wx.ID_ANY, text="Display Application Log...",
-                                      help="Displays the NDIToolbox application log")
+                                      helpString="Displays the NDIToolbox application log")
         self.Bind(wx.EVT_MENU, self.controller.on_display_log, id=displaylog_mnui.GetId())
         self.help_mnu.AppendItem(displaylog_mnui)
         clearlog_mnui = wx.MenuItem(self.help_mnu, wx.ID_ANY, text="Clear Application Log",
-                                    help="Deletes the NDIToolbox application log")
+                                    helpString="Deletes the NDIToolbox application log")
         self.Bind(wx.EVT_MENU, self.controller.on_clear_log, id=clearlog_mnui.GetId())
         self.help_mnu.AppendItem(clearlog_mnui)
         self.menubar.Append(self.help_mnu, "&Help")
@@ -200,9 +200,13 @@ class UI(wx.Frame):
         self.toolbar = self.CreateToolBar(wx.TB_FLAT | wx.TB_NODIVIDER | wx.NO_BORDER)
         self.toolbar.SetToolBitmapSize((16, 16))
         # Toggle button to enable / disable automatic previews of data
-        self.gen_bitmaps_tool = self.toolbar.AddCheckTool(id=wx.ID_ANY,
-                                                          shortHelp='Enable Data Thumbnails',
-                                                          bitmap=self.controller.get_bitmap('Picture.png'))
+        # Note: shortHelp should be accepted as an argument to AddCheckTool info
+        # wxPython 4.0.3 but for some reason it is not recognized
+        self.gen_bitmaps_tool = self.toolbar.AddCheckTool(toolId=wx.ID_ANY,
+                                                          label="Thumbnails",
+                                                          bitmap1=self.controller.get_bitmap('Picture.png'),
+#                                                          shortHelp='Enable Data Thumbnails'
+                                                          )
         self.toolbar.ToggleTool(self.gen_bitmaps_tool.GetId(),
                                 self.controller.get_preview_state())
         self.Bind(wx.EVT_TOOL, self.controller.on_preview_toggle, self.gen_bitmaps_tool)

--- a/views/plotwindow.py
+++ b/views/plotwindow.py
@@ -13,7 +13,7 @@ import wx
 from matplotlib.figure import Figure
 from matplotlib.widgets import Cursor
 from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
-from matplotlib.backends.backend_wxagg import NavigationToolbar2Wx
+from matplotlib.backends.backend_wxagg import NavigationToolbar2WxAgg
 import os.path
 import Queue
 

--- a/views/podtk.py
+++ b/views/podtk.py
@@ -42,33 +42,33 @@ class PODWindow(wx.Frame):
 
         self.file_mnu = wx.Menu() # File menu
         quit_mnui = wx.MenuItem(self.file_mnu, wx.ID_ANY, text="Close Window\tCTRL+W",
-                                help="Exits PODToolkit")
+                                helpString="Exits PODToolkit")
         self.file_mnu.AppendItem(quit_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_quit, quit_mnui)
         self.menubar.Append(self.file_mnu, "&File")
 
         self.models_mnu = wx.Menu() # Models menu
         #addmodel_mnui = wx.MenuItem(self.models_mnu, wx.ID_ANY, text="Add A Model\tCTRL+A",
-        #                            help="Adds a POD model to the available models")
+        #                            helpString="Adds a POD model to the available models")
         #self.Bind(wx.EVT_MENU, self.controller.on_add_model, addmodel_mnui)
         #self.models_mnu.AppendItem(addmodel_mnui)
 
         install_plugin_mnui = wx.MenuItem(self.models_mnu, wx.ID_ANY, text="Install Model...",
-                                          help="Install a local POD Model")
+                                          helpString="Install a local POD Model")
         self.Bind(wx.EVT_MENU, self.controller.on_install_model, id=install_plugin_mnui.GetId())
         self.models_mnu.AppendItem(install_plugin_mnui)
         download_plugin_mnui = wx.MenuItem(self.models_mnu, wx.ID_ANY, text="Download Model...",
-                                           help="Download and install a new POD Model")
+                                           helpString="Download and install a new POD Model")
         self.Bind(wx.EVT_MENU, self.controller.on_download_model, id=download_plugin_mnui.GetId())
         self.models_mnu.AppendItem(download_plugin_mnui)
 
         savemodel_mnui = wx.MenuItem(self.models_mnu, wx.ID_ANY,
                                      text="Save Model Configuration",
-                                     help="Saves the current model configuration to disk\tCTRL+W")
+                                     helpString="Saves the current model configuration to disk\tCTRL+W")
         self.Bind(wx.EVT_MENU, self.controller.on_save_model, savemodel_mnui)
         self.models_mnu.AppendItem(savemodel_mnui)
         #deletemodel_mnui = wx.MenuItem(self.models_mnu, wx.ID_ANY, text="Remove Current Model",
-        #                               help="Removes the currently selected POD model from the " \
+        #                               helpString="Removes the currently selected POD model from the " \
         #                                    "workspace")
         #self.Bind(wx.EVT_MENU, self.controller.on_delete_model, deletemodel_mnui)
         #self.models_mnu.AppendItem(deletemodel_mnui)
@@ -76,7 +76,7 @@ class PODWindow(wx.Frame):
 
         self.ops_mnu = wx.Menu() # Operations menu
         run_mnui = wx.MenuItem(self.ops_mnu, wx.ID_ANY, text="Run\tCTRL+R",
-                               help="Runs the current model")
+                               helpString="Runs the current model")
         self.ops_mnu.AppendItem(run_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_runmodel, run_mnui)
 
@@ -84,11 +84,11 @@ class PODWindow(wx.Frame):
 
         self.help_mnu = wx.Menu() # Basic Help menu
         about_mnui = wx.MenuItem(self.help_mnu, wx.ID_ANY, text="About POD Toolkit",
-                                 help="About this program")
+                                 helpString="About this program")
         self.help_mnu.AppendItem(about_mnui)
         self.Bind(wx.EVT_MENU, self.controller.on_about, about_mnui)
         help_mnui = wx.MenuItem(self.help_mnu, wx.ID_ANY, text="Usage Basics",
-                                help="A rundown of how to use POD Toolkit to get you started")
+                                helpString="A rundown of how to use POD Toolkit to get you started")
         self.Bind(wx.EVT_MENU, self.controller.on_help, help_mnui)
         self.help_mnu.AppendItem(help_mnui)
         self.menubar.Append(self.help_mnu, "&Help")
@@ -213,7 +213,7 @@ class PODWindow(wx.Frame):
         self.modelprops_panel_sizer.Add(self.mp_lbl, ui_defaults.lbl_pct,
                                         ui_defaults.sizer_flags, ui_defaults.widget_margin)
         self.mp_grid = wxspreadsheet.Spreadsheet(self.modelprops_panel)
-        self.Bind(wx.grid.EVT_GRID_CELL_CHANGE, self.controller.on_property_change)
+        self.Bind(wx.grid.EVT_GRID_CELL_CHANGED, self.controller.on_property_change)
         self.mp_grid.SetNumberRows(1)
         self.mp_grid.SetNumberCols(2)
         self.mp_grid.SetRowLabelSize(1)


### PR DESCRIPTION
Hi,

It wasn't clear which version of wxPython NDIToolbox was designed to work with so I updated API calls for a few functions so the application would run under wxPython 4.0.3 (latest production version as of 8/15/2018).

Functional testing has been minimal and there are many deprecation warning as well as additional unresolved errors (e.g. "Help | About This Program..." throws "TypeError: Dialog(): arguments did not match any overloaded call"), however, the program starts and runs well enough to be tested further.

This pul request is meant as an initial point for upgrading to wxPython 4.x should that be desirable.

Thanks,
-- Bob